### PR TITLE
Faker structs and different setups

### DIFF
--- a/collect.sh
+++ b/collect.sh
@@ -1,35 +1,100 @@
+#!/bin/bash
+
 # Generate fake data and send it to the started worker thread. It will
 # then collect data on how many that actually made it, since this is
 # UDP packets will be dropped if they are not processed fast enough.
+
+function usage() {
+    cat <<EOF 1>&2
+Usage: bash collect.sh [ -s <scheme> ]
+Collect measurements for scheme.
+
+This will generate fake data and send it to the started worker thread
+(see script setup.sql). It will then collect data on how many that
+actually made it, since this is UDP packets will be dropped if they
+are not processed fast enough.
+
+The measurements will be stored under version of the extension plus
+scheme name.
+EOF
+    exit 2
+}
+
 VERSION=$(echo $(psql -t -c "select extversion from pg_extension where extname = 'influx'"))
-echo "Measure ${COUNT:=1000000} lines for version '$VERSION'"
+SCHEME=basic
+
+while getopts "t:" opt; do
+    case $opt in
+	s)
+	    SCHEME=$OPTARG
+	    ;;
+	*)
+	    usage
+	    ;;
+    esac
+done
+
+if [[ -z "$SCHEME" ]]; then
+    echo "You need to provide a scheme to use" 1>&2
+    exit 2
+elif ! [[ -r "scheme/$SCHEME.sh" ]]; then
+    echo "You need to have a file $SCHEME.sh containing the scheme" 1>&2
+    exit 2
+fi
+
+# Each scheme is in a file with functions to handle each primitive
+# action.
+#
+# setup_schema:
+#    Create the initial schema and tables to receive the data
+#
+# reset_schema:
+#    Reset the schema and tables to prepare for a run.
+#
+# wait_until_stable:
+#    Wait for the processing to stabilize
+#
+# record_measurements:
+#    Record measurements from the tables
+#
+# The following environment variables are set up for use in the
+# functions:
+#
+# VERSION:
+#    Extension version
+#
+# SCHEME:
+#    Name of the scheme. The name of the file, for now.
+#
+# COUNT:
+#    Number of rows sent to the port.
+
+echo "Measure ${COUNT:=1000000} lines for version '$VERSION' scheme $SCHEME"
+
+source scheme/$SCHEME.sh
+
+set -e
+
+function show_measurements () {
+    psql -q <<EOF
+SELECT version, scheme, total, count(*), avg(count::decimal), stddev(count)
+  FROM measurements GROUP BY version, scheme, total
+EOF
+}
+
+setup_scheme
 while true; do
-    psql -q -c 'TRUNCATE magic.swap, magic.cpu, magic.disk, magic.diskio'
+    reset_scheme
     cargo run -q 127.0.0.1:4711 $COUNT
 
     # Since the lines are processed in the background, we can still be
     # processing lines even though we have stopped sending then.
     #
-    # Wait until the count is stable. Then all lines should have been
-    # processed. We start at -1 since a very fast check might give
-    # zero back.
-    echo -n "Waiting.."
-    prev=-1
-    while true; do
-	cnt=$(psql -t -c "SELECT count(*) FROM combined")
-	if [ $cnt -eq $prev ]; then
-	    break
-	fi
-	prev=$cnt
-	echo -n "."
-	sleep 1
-    done
-    echo "stable (at $(echo $cnt))"
-    psql -q -c "INSERT INTO measurements(time, count, total, version) SELECT now(), count(*), $COUNT, '$VERSION' FROM combined"
-    psql -c 'SELECT version, count(*), avg(count::decimal), stddev(count) FROM measurements GROUP BY version, total'
-
+    wait_until_stable
+    record_measurements
+    show_measurements
     # If we have a 100 measurements, we can stop.
-    count=$(psql -t -c "SELECT count(*) FROM measurements WHERE version = '$VERSION'")
+    count=$(psql -t -c "SELECT count(*) FROM measurements WHERE version = '$VERSION' AND scheme = '$SCHEME'")
     if [ $count -ge 100 ]; then
 	break
     fi

--- a/scheme/basic.sh
+++ b/scheme/basic.sh
@@ -1,0 +1,74 @@
+function setup_scheme () {
+    psql -q <<EOF
+CREATE SCHEMA IF NOT EXISTS magic;
+
+DROP VIEW IF EXISTS combined;
+DROP TABLE IF EXISTS magic.cpu;
+DROP TABLE IF EXISTS magic.disk;
+DROP TABLE IF EXISTS magic.swap;
+DROP TABLE IF EXISTS magic.diskio;
+
+CREATE TABLE magic.cpu (
+    _time timestamptz,
+    _tags jsonb,
+    _fields jsonb
+);
+
+CREATE TABLE magic.swap (
+    _time timestamptz,
+    _tags jsonb,
+    _fields jsonb
+);
+
+CREATE TABLE magic.disk (
+    _time timestamptz,
+    _tags jsonb,
+    _fields jsonb
+);
+
+CREATE TABLE magic.diskio (
+    _time timestamptz,
+    _tags jsonb,
+    _fields jsonb
+);
+
+CREATE VIEW combined AS
+    SELECT _time, _tags, _fields FROM magic.cpu
+  UNION ALL
+    SELECT _time, _tags, _fields FROM magic.swap
+  UNION ALL
+    SELECT _time, _tags, _fields FROM magic.disk
+  UNION ALL
+    SELECT _time, _tags, _fields FROM magic.diskio;
+EOF
+}
+
+function reset_scheme () {
+    psql -q -c 'TRUNCATE magic.swap, magic.cpu, magic.disk, magic.diskio'
+}
+
+# Wait until the count is stable.
+#
+# Then all lines should have been processed. We start at -1 since a
+# very fast check might give zero back.
+function wait_until_stable () {
+    echo -n "Waiting.."
+    prev=-1
+    while true; do
+	cnt=$(psql -t -c "SELECT count(*) FROM combined")
+	if [[ $cnt -eq $prev ]]; then
+	    break
+	fi
+	prev=$cnt
+	echo -n "."
+	sleep 1
+    done
+    echo "stable (at $(echo $cnt))"
+}
+
+function record_measurements () {
+    psql -q <<EOF
+INSERT INTO measurements(time, count, total, version, scheme)
+SELECT now(), count(*), $COUNT, '$VERSION', '$SCHEME' FROM combined
+EOF
+}

--- a/setup.sql
+++ b/setup.sql
@@ -1,16 +1,37 @@
 -- Set up the tables in the magic schema and create the measurements
 -- table and a view to measure the total number of rows inserted.
 CREATE SCHEMA magic;
-CREATE TABLE IF NOT EXISTS magic.cpu (
+
+DROP VIEW IF EXISTS combined;
+DROP TABLE IF EXISTS magic.cpu;
+DROP TABLE IF EXISTS magic.disk;
+DROP TABLE IF EXISTS magic.swap;
+DROP TABLE IF EXISTS magic.diskio;
+
+CREATE TABLE magic.cpu (
+    _time timestamptz,
+    cpu text,
+    host text
+);
+
+CREATE TABLE magic.swap (
     _time timestamptz,
     _tags jsonb,
     _fields jsonb
 );
-CREATE TABLE IF NOT EXISTS magic.swap (LIKE magic.cpu);
-CREATE TABLE IF NOT EXISTS magic.disk (LIKE magic.cpu);
-CREATE TABLE IF NOT EXISTS magic.diskio (LIKE magic.cpu);
 
-DROP VIEW IF EXISTS combined;
+CREATE TABLE magic.disk (
+    _time timestamptz,
+    _tags jsonb,
+    _fields jsonb
+);
+
+CREATE TABLE magic.diskio (
+    _time timestamptz,
+    _tags jsonb,
+    _fields jsonb
+);
+
 CREATE VIEW combined AS
     SELECT _time, _tags, _fields FROM magic.cpu
   UNION ALL

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1,0 +1,42 @@
+use fake::faker::lorem::en::Word;
+use fake::faker::number::en::NumberWithFormat;
+use fake::Fake;
+use fake::{Dummy, Faker};
+use rand::Rng;
+use std::fmt;
+
+pub struct Cpu {
+    cpu: String,
+    host: String,
+    usage_idle: f32,
+    usage_iowait: f32,
+    usage_nice: f32,
+    usage_system: f32,
+    usage_user: f32,
+    timestamp: u64,
+}
+
+impl Dummy<Faker> for Cpu {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        Cpu {
+            cpu: NumberWithFormat("cpu#").fake_with_rng(rng),
+            usage_user: (0.0..10.0).fake_with_rng(rng),
+            usage_idle: (0.0..10.0).fake_with_rng(rng),
+            usage_nice: (0.0..10.0).fake_with_rng(rng),
+            usage_iowait: (0.0..10.0).fake_with_rng(rng),
+            usage_system: (0.0..10.0).fake_with_rng(rng),
+            host: Word().fake_with_rng(rng),
+            timestamp: Faker.fake_with_rng(rng),
+        }
+    }
+}
+
+impl fmt::Display for Cpu {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "cpu,cpu={},host={} usage_idle={},usage_iowait={},usage_nice={},usage_system={},usage_user={} {}",
+            self.cpu, self.host, self.usage_idle, self.usage_iowait, self.usage_nice, self.usage_system, self.usage_user, self.timestamp
+        )
+    }
+}

--- a/src/diskio.rs
+++ b/src/diskio.rs
@@ -1,0 +1,37 @@
+use fake::faker::lorem::en::Word;
+use fake::Fake;
+use fake::{Dummy, Faker};
+use rand::Rng;
+use std::fmt;
+
+pub struct DiskIO {
+    host: String,
+    name: String,
+    io_time: f32,
+    read_bytes: u32,
+    write_bytes: u32,
+    timestamp: u64,
+}
+
+impl fmt::Display for DiskIO {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "diskio,host={},name={} io_time={}i,read_bytes={}i,write_bytes={}i {}",
+            self.host, self.name, self.io_time, self.read_bytes, self.write_bytes, self.timestamp
+        )
+    }
+}
+
+impl Dummy<Faker> for DiskIO {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        DiskIO {
+            host: Word().fake_with_rng(rng),
+            name: Word().fake_with_rng(rng),
+            io_time: Faker.fake_with_rng(rng),
+            read_bytes: Faker.fake_with_rng(rng),
+            write_bytes: Faker.fake_with_rng(rng),
+            timestamp: Faker.fake_with_rng(rng),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,7 @@
+mod cpu;
+mod diskio;
+mod swap;
+
+pub use cpu::Cpu;
+pub use diskio::DiskIO;
+pub use swap::Swap;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,50 +1,12 @@
 use fake::faker::filesystem::raw::*;
 use fake::faker::lorem::raw::*;
-use fake::faker::number::raw::*;
 use fake::locales::EN;
 use fake::{Fake, Faker};
+use influx_faker::*;
 use rand::Rng;
 use std::env::args;
 use std::error::Error;
-use std::net::SocketAddr;
-use std::net::UdpSocket;
-
-fn fake_swap() -> String {
-    format!(
-        "swap,host={} free={}i,total={}i,used={}i,used_percent={} {}",
-        Word(EN).fake::<String>(),
-        Faker.fake::<u32>(),
-        Faker.fake::<u32>(),
-        Faker.fake::<u32>(),
-        (0.0..1.0).fake::<f32>(),
-        Faker.fake::<u64>(),
-    )
-}
-
-fn fake_cpu() -> String {
-    format!("cpu,cpu={},host={} usage_idle={},usage_iowait={},usage_nice={},usage_system={},usage_user={} {}\n",
-            NumberWithFormat(EN, "cpu#").fake::<String>(),
-            Word(EN).fake::<String>(),
-            (0.0..6.0).fake::<f32>(),
-            (0.0..6.0).fake::<f32>(),
-            (0.0..6.0).fake::<f32>(),
-            (0.0..6.0).fake::<f32>(),
-            (0.0..6.0).fake::<f32>(),
-        Faker.fake::<u64>(),
-    )
-}
-
-fn fake_diskio() -> String {
-    format!(
-        "diskio,host={},name={} io_time={}i,read_bytes={}i,write_bytes={}i {}\n",
-        Word(EN).fake::<String>(),
-        Word(EN).fake::<String>(),
-        Faker.fake::<f32>(),
-        Faker.fake::<u32>(),
-        Faker.fake::<u32>(),
-        Faker.fake::<u64>(),
-    )
-}
+use std::net::{SocketAddr, UdpSocket};
 
 fn fake_disk() -> String {
     format!("disk,device={},fstype={},host={},mode={},path={} free={}i,inodes_free={}i,inodes_total={}i,inodes_used={}i,total={}i,used={}i,used_percent={} {}\n",
@@ -65,7 +27,12 @@ fn fake_disk() -> String {
 }
 
 fn random_line<R: Rng>(rng: &mut R) -> String {
-    let alt: Vec<fn() -> String> = vec![fake_swap, fake_diskio, fake_cpu, fake_disk];
+    let alt: Vec<fn() -> String> = vec![
+        || Faker.fake::<Swap>().to_string(),
+        || Faker.fake::<DiskIO>().to_string(),
+        || Faker.fake::<Cpu>().to_string(),
+        fake_disk,
+    ];
     alt[rng.gen::<usize>() % alt.len()]()
 }
 

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -1,0 +1,40 @@
+use fake::faker::lorem::en::Word;
+use fake::Fake;
+use fake::{Dummy, Faker};
+use rand::Rng;
+use std::fmt;
+
+pub struct Swap {
+    host: String,
+    free: u32,
+    total: u32,
+    used: u32,
+    used_percent: f32,
+    timestamp: u64,
+}
+
+impl fmt::Display for Swap {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "swap,host={} free={}i,total={}i,used={}i,used_percent={} {}",
+            self.host, self.free, self.total, self.used, self.used_percent, self.timestamp
+        )
+    }
+}
+
+impl Dummy<Faker> for Swap {
+    fn dummy_with_rng<R: Rng + ?Sized>(_: &Faker, rng: &mut R) -> Self {
+        let total: u32 = Faker.fake_with_rng(rng);
+        let used: u32 = (0..total).fake_with_rng(rng);
+
+        Swap {
+            host: Word().fake_with_rng(rng),
+            used: used,
+            free: total - used,
+            total: total,
+            used_percent: used as f32 / total as f32,
+            timestamp: Faker.fake_with_rng(rng),
+        }
+    }
+}


### PR DESCRIPTION
Support different schemes
    
Adding support for different schemes when doing benchmarking. Each
scheme is represented as a file with functions that are called to
perform each step in the benchmarking process. Schemes can have
different tables for storing the received data.

----

Adding faker structs
    
In order to make the lines generated more configurable, there is
one struct for each kind of line.
