### PR TITLE
Support selecting schemes and versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,33 @@ PGDATA=/var/lib/pgsql/13/data
 psql -f setup.sql
 ```
 
-After that, prepare for execution of one version by running the script
-`reset.sh`. This is done once after installing the `influx` package
-you want to check. This will:
+If you are using a remote connection, you can set the traditional
+`psql` variables `PGHOST`, `PGPORT` (if it is not the default 5432),
+and `PGPASSWORD` (if you use password authentication).
 
-1. Remove the old extension
-2. Terminate all Influx backends
-3. Reinstall the Influx package (with the default version)
-4. Start a worker listening on port 4711 and writing to schema `magic`
+```bash
+PATH=/usr/local/postgresql/13.5/bin:$PATH
+PGHOST=capulet.lan
+PGPASSWORD=xyzzy
+psql -f setup.sql
+```
 
 You can now run the collection of data using `collect.sh`, which is
 taking 100 samples of of the run in the following manner:
-1. Fetch the version of the extension
-2. Truncate the tables in schema `magic`
-3. Run the generator to write to port 4711 on localhost using UDP
-4. Wait for the count to be stable, indicating that the worker is done
+1. Reset the old extension by:
+   1. Remove the old extension
+   2. Terminate all Influx backends
+   3. Reinstall the Influx package (with the default version)
+   4. Start a worker listening on port 4711 and writing to schema `magic`
+2. Fetch the version of the extension
+3. Truncate the tables in schema `magic`
+4. Run the generator to write to port provided to `-p` argument and
+   host given by `$PGHOST` using UDP.
+5. Wait for the count to be stable, indicating that the worker is done
    processing the lines.
-5. Insert version, timestamp, a total count of rows, and the number of
+6. Insert version, timestamp, a total count of rows, and the number of
    rows sent into the table `public.measurements`.
-6. Repeat steps 2-5 until there are 100 measurements.
+7. Repeat steps 3-6 until there are 100 measurements.
 
 If you stop the script, it will leave existing measurements in the
 table and just fill up until the count is 100.

--- a/plot.r
+++ b/plot.r
@@ -1,9 +1,14 @@
 library('RPostgreSQL')
 library(ggplot2)
 
+DB <- Sys.getenv("PGDATABASE")
+HOST <- Sys.getenv("PGHOST")
+PORT <- Sys.getenv("PGPORT")
+
 pg = dbDriver("PostgreSQL")
-con = dbConnect(pg, dbname="influx", host="localhost", port=5432)
+con = dbConnect(pg, dbname=DB, host=HOST, port=PORT)
 table = dbGetQuery(con, "SELECT * FROM measurements")
+
 ggplot(table, aes(x=as.factor(version), y=count)) + 
     geom_boxplot(fill="slateblue", alpha=0.2) + 
     xlab("version")

--- a/setup.sql
+++ b/setup.sql
@@ -1,48 +1,6 @@
--- Set up the tables in the magic schema and create the measurements
--- table and a view to measure the total number of rows inserted.
-CREATE SCHEMA magic;
-
-DROP VIEW IF EXISTS combined;
-DROP TABLE IF EXISTS magic.cpu;
-DROP TABLE IF EXISTS magic.disk;
-DROP TABLE IF EXISTS magic.swap;
-DROP TABLE IF EXISTS magic.diskio;
-
-CREATE TABLE magic.cpu (
-    _time timestamptz,
-    cpu text,
-    host text
-);
-
-CREATE TABLE magic.swap (
-    _time timestamptz,
-    _tags jsonb,
-    _fields jsonb
-);
-
-CREATE TABLE magic.disk (
-    _time timestamptz,
-    _tags jsonb,
-    _fields jsonb
-);
-
-CREATE TABLE magic.diskio (
-    _time timestamptz,
-    _tags jsonb,
-    _fields jsonb
-);
-
-CREATE VIEW combined AS
-    SELECT _time, _tags, _fields FROM magic.cpu
-  UNION ALL
-    SELECT _time, _tags, _fields FROM magic.swap
-  UNION ALL
-    SELECT _time, _tags, _fields FROM magic.disk
-  UNION ALL
-    SELECT _time, _tags, _fields FROM magic.diskio;
-
 CREATE TABLE IF NOT EXISTS measurements (
    time timestamptz,
+   scheme text,
    version text,
    count int,
    total int 


### PR DESCRIPTION
Adding support for selecting different schemes using the option `-s`
when doing benchmarking.

Each scheme is represented as a file with functions that are called to
perform each step in the benchmarking process. Schemes can have
different tables for storing the received data.

It also add options to pick a specific version to use when running the
measurements using the `-v` flag. If no version is picked, the default
version will be used.

Also add support for connecting to different ports.