### PR TITLE
Support DNS lookup in faker

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -3,9 +3,14 @@ name: Rust
 on:
   push:
     branches: [ "main" ]
+    paths:
+      - '**.rs'
+      - '**.toml'
   pull_request:
     branches: [ "main" ]
-
+    paths:
+      - '**.rs'
+      - '**.toml'
 env:
   CARGO_TERM_COLOR: always
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,8 @@ use influx_faker::*;
 use rand::Rng;
 use std::env::args;
 use std::error::Error;
-use std::net::{SocketAddr, UdpSocket};
+use std::net::ToSocketAddrs;
+use std::net::UdpSocket;
 
 fn fake_disk() -> String {
     format!("disk,device={},fstype={},host={},mode={},path={} free={}i,inodes_free={}i,inodes_total={}i,inodes_used={}i,total={}i,used={}i,used_percent={} {}\n",
@@ -39,7 +40,10 @@ fn random_line<R: Rng>(rng: &mut R) -> String {
 fn main() -> Result<(), Box<dyn Error>> {
     let socket = UdpSocket::bind("0.0.0.0:0")?;
     let mut rng = rand::thread_rng();
-    let addr: SocketAddr = args().nth(1).unwrap().parse()?;
+    let addr_string: String = args().nth(1).unwrap();
+    let mut addrs = addr_string.as_str().to_socket_addrs().unwrap();
+    let addr = addrs.next().unwrap();
+    //    let addr: SocketAddr = addr.as_str().to_socket_addrs()?;
     let count: usize = match args().nth(2) {
         Some(x) => x.parse()?,
         None => 100000,


### PR DESCRIPTION
Using only `SocketAddr` does not do a DNS lookup, so using `to_socket_addrs` method to do that.